### PR TITLE
Handle JournalEntryExerciseMarker

### DIFF
--- a/openapscontrib/predict/__init__.py
+++ b/openapscontrib/predict/__init__.py
@@ -6,13 +6,16 @@ predict - tools for predicting glucose trends
 from .version import __version__
 
 import argparse
+from datetime import datetime, timedelta
 from dateutil.parser import parse
 import json
+import os
 
 from openaps.uses.use import Use
 
 from predict import Schedule
 from predict import future_glucose
+from predict import glucose_data_tuple
 
 
 # set_config is needed by openaps for all vendors.
@@ -147,9 +150,18 @@ class glucose(Use):
         :return:
         :rtype: tuple(list, dict)
         """
+        pump_history_file_time = datetime.fromtimestamp(os.path.getmtime(params['pump-history']))
+        assert datetime.now() - pump_history_file_time < timedelta(minutes=5), 'History data is more than 5 minutes old'
+
+        recent_glucose = _json_file(params['glucose'])
+        glucose_file_time = datetime.fromtimestamp(os.path.getmtime(params['glucose']))
+        last_glucose_datetime, _ = glucose_data_tuple(recent_glucose[0])
+        assert abs(glucose_file_time - last_glucose_datetime) < timedelta(minutes=15), \
+            'Glucose data is more than 15 minutes old'
+
         args = (
             _json_file(params['pump-history']),
-            _json_file(params['glucose']),
+            recent_glucose,
             params.get('insulin_action_curve', None) or
             _opt_json_file(params.get('settings', ''))['insulin_action_curve'],
             Schedule(_json_file(params['insulin_sensitivities'])['sensitivities']),

--- a/openapscontrib/predict/models.py
+++ b/openapscontrib/predict/models.py
@@ -1,0 +1,8 @@
+
+
+class Unit(object):
+    event = "event"
+    grams = "g"
+    percent_of_basal = "percent"
+    units = "U"
+    units_per_hour = "U/hour"

--- a/openapscontrib/predict/predict.py
+++ b/openapscontrib/predict/predict.py
@@ -2,7 +2,7 @@ import datetime
 from dateutil.parser import parse
 import math
 
-from openapscontrib.mmhistorytools.models import Unit
+from models import Unit
 
 
 class Schedule(object):

--- a/openapscontrib/predict/predict.py
+++ b/openapscontrib/predict/predict.py
@@ -34,6 +34,13 @@ class Schedule(object):
         return result
 
 
+def glucose_data_tuple(glucose_entry):
+    return (
+        parse(glucose_entry.get('date') or glucose_entry['display_time']),
+        glucose_entry.get('sgv') or glucose_entry.get('amount') or glucose_entry['glucose']
+    )
+
+
 def carb_effect_curve(t, absorption_time):
     """Returns the fraction of total carbohydrate effect with a given absorption time on blood
     glucose at the specified number of minutes after eating.
@@ -151,9 +158,7 @@ def future_glucose(
     if len(recent_glucose) == 0:
         return []
 
-    last_glucose_entry = recent_glucose[0]
-    last_glucose_value = last_glucose_entry.get('sgv') or last_glucose_entry.get('amount') or last_glucose_entry['glucose']
-    last_glucose_datetime = parse(last_glucose_entry.get('date') or last_glucose_entry['display_time'])
+    last_glucose_datetime, last_glucose_value = glucose_data_tuple(recent_glucose[0])
 
     # Determine our simulation time.
     simulation_start = last_glucose_datetime

--- a/openapscontrib/predict/predict.py
+++ b/openapscontrib/predict/predict.py
@@ -217,6 +217,9 @@ def future_glucose(
 
                 effect = temp_basal_effect_at_datetime(history_event, t, 0, t1, insulin_sensitivity, insulin_action_curve)
                 apply_to = insulin_effect
+            elif history_event['unit'] == Unit.event:
+                # effect added through use of exercise marker (JournalEntryExerciseMarker) in x23 models
+                pass
             else:
                 raise ValueError('Unknown event %s', history_event)
 

--- a/openapscontrib/predict/predict.py
+++ b/openapscontrib/predict/predict.py
@@ -219,7 +219,7 @@ def future_glucose(
                 apply_to = insulin_effect
             elif history_event['unit'] == Unit.event:
                 # effect added through use of exercise marker (JournalEntryExerciseMarker) in x23 models
-                pass
+                break
             else:
                 raise ValueError('Unknown event %s', history_event)
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ long_description = '''openaps predict plugin
 This package is a vendor plugin for openaps that provides tools for predicting glucose trends.
 '''
 
-requires = ['python-dateutil', 'openapscontrib.mmhistorytools']
+requires = ['openaps', 'python-dateutil']
 
 __version__ = None
 exec(open('openapscontrib/predict/version.py').read())

--- a/tests/predict_tests.py
+++ b/tests/predict_tests.py
@@ -282,9 +282,9 @@ class FutureGlucoseTestCase(unittest.TestCase):
     def test_single_bolus_with_excercise_marker(self):
         normalized_history = [
             {
-                "start_at": "2015-09-07T22:23:08", 
+                "start_at": "2015-07-13T12:23:08", 
                 "description": "JournalEntryExerciseMarker", 
-                "end_at": "2015-09-07T22:23:08", 
+                "end_at": "2015-07-13T12:23:08", 
                 "amount": 1, 
                 "type": "Exercise", 
                 "unit": "event"

--- a/tests/predict_tests.py
+++ b/tests/predict_tests.py
@@ -282,9 +282,9 @@ class FutureGlucoseTestCase(unittest.TestCase):
     def test_single_bolus_with_excercise_marker(self):
         normalized_history = [
             {
-                "start_at": "2015-07-13T12:23:08", 
+                "start_at": "2015-07-13T12:05:00", 
                 "description": "JournalEntryExerciseMarker", 
-                "end_at": "2015-07-13T12:23:08", 
+                "end_at": "2015-07-13T12:05:00", 
                 "amount": 1, 
                 "type": "Exercise", 
                 "unit": "event"
@@ -314,7 +314,7 @@ class FutureGlucoseTestCase(unittest.TestCase):
         )
 
         self.assertDictEqual({'date': '2015-07-13T12:00:00', 'glucose': 150.0}, glucose[0])
-        self.assertDictEqual({'date': '2015-07-13T16:10:00', 'glucose': 110.0}, glucose[-1])
+        self.assertDictEqual({'date': '2015-07-13T16:15:00', 'glucose': 110.0}, glucose[-1])
 
     def test_fake_unit(self):
         normalized_history = [

--- a/tests/predict_tests.py
+++ b/tests/predict_tests.py
@@ -278,3 +278,68 @@ class FutureGlucoseTestCase(unittest.TestCase):
         )
 
         self.assertListEqual([], glucose)
+
+    def test_single_bolus_with_excercise_marker(self):
+        normalized_history = [
+            {
+                "start_at": "2015-09-07T22:23:08", 
+                "description": "JournalEntryExerciseMarker", 
+                "end_at": "2015-09-07T22:23:08", 
+                "amount": 1, 
+                "type": "Exercise", 
+                "unit": "event"
+            },
+            {
+                "type": "Bolus",
+                "start_at": "2015-07-13T12:00:00",
+                "end_at": "2015-07-13T12:00:00",
+                "amount": 1.0,
+                "unit": "U"
+            }
+        ]
+
+        normalized_glucose = [
+            {
+                "date": "2015-07-13T12:00:00",
+                "sgv": 150
+            }
+        ]
+
+        glucose = future_glucose(
+            normalized_history,
+            normalized_glucose,
+            4,
+            Schedule(self.insulin_sensitivities['sensitivities']),
+            Schedule(self.carb_ratios['schedule'])
+        )
+
+        self.assertDictEqual({'date': '2015-07-13T12:00:00', 'glucose': 150.0}, glucose[0])
+        self.assertDictEqual({'date': '2015-07-13T16:10:00', 'glucose': 110.0}, glucose[-1])
+
+    def test_fake_unit(self):
+        normalized_history = [
+            {
+                "start_at": "2015-09-07T22:23:08", 
+                "description": "JournalEntryExerciseMarker", 
+                "end_at": "2015-09-07T22:23:08", 
+                "amount": 1, 
+                "type": "Exercise", 
+                "unit": "beer"
+            }
+        ]
+
+        normalized_glucose = [
+            {
+                "date": "2015-07-13T12:00:00",
+                "sgv": 150
+            }
+        ]
+
+        with self.assertRaises(ValueError):
+            glucose = future_glucose(
+            normalized_history,
+            normalized_glucose,
+            4,
+            Schedule(self.insulin_sensitivities['sensitivities']),
+            Schedule(self.carb_ratios['schedule'])
+            ) 


### PR DESCRIPTION
Can handle exercise markers (`JournalEntryExerciseMarker`) in x23 models. For now, does not add them to any BG effect.

Also added tests for false unit types.